### PR TITLE
Add new vtu_dump function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,5 @@
 ## 0.1.0 (not yet released)
 
 - Initial code import [#1](https://github.com/mcflugen/landlab-parallel/issues/1)
+- Added new function, `vtu_dump` that dumps a *landlab* grid to *vtu* format
+  [#2](https://github.com/mcflugen/landlab-parallel/issues/2).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "landlab",
+    "meshio",
     "numpy",
     "pymetis",
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 landlab
+meshio
 numpy
 pymetis

--- a/run_example.py
+++ b/run_example.py
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 from landlab_parallel import RasterTiler
 from landlab_parallel import Tile
 from landlab_parallel import create_landlab_grid
+from landlab_parallel import vtu_dump
 
 
 def run(shape):
@@ -91,6 +92,9 @@ def run(shape):
         send_receive_ghost_data(
             comm, my_ghosts, their_ghosts, grid.at_node["topographic__elevation"]
         )
+
+    with open(f"{RANK}.vtu", "w") as fp:
+        fp.write(vtu_dump(grid, z_coord="topographic__elevation"))
 
     if RANK == 0:
         tile_data = {0: grid.at_node["topographic__elevation"]}


### PR DESCRIPTION
I've added a new function, `vtu_dump`, that writes a grid's data to a *vtu* file. This is just a wrapper for `landlab.io.legacy_vtk.dump`, and could be optimized if it proves to be slow. As written, `vtu_dump` writes a grid to legacy *vtk* format, reads that file using `meshio`, and then dumps  that mesh to a string in *vtu* format (again using `meshio`). It seems to be fast enough for now but probably a new *Landlab* function to dump a grid to *vtu* directly is in order.

I've added this capability so that we will be able to piece together the individual *vtu* files, which are written by each process, into a *pvtu* file.