### PR TITLE
Fix lower left of tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,3 +7,5 @@
   [#2](https://github.com/mcflugen/landlab-parallel/issues/2).
 - Added new function, `pvtu_dump`, that compbines a set of *vtu* files
   [#3](https://github.com/mcflugen/landlab-parallel/issues/3).
+- Fixed an issue where the lower-left corner of the tiles were not be calculated
+  correctly [#4](https://github.com/mcflugen/landlab-parallel/issues/4).

--- a/landlab_parallel.py
+++ b/landlab_parallel.py
@@ -321,7 +321,7 @@ def create_landlab_grid(
 ):
     partition = np.asarray(partition)
 
-    if mode == "d4":
+    if mode in ("d4", "raster"):
         grid = landlab.RasterModelGrid(
             partition.shape,
             xy_spacing=spacing,

--- a/run_example.py
+++ b/run_example.py
@@ -22,6 +22,8 @@ def run(shape):
     RANK = comm.Get_rank()
     n_partitions = comm.Get_size()
 
+    mode = "odd-r"
+
     if RANK == 0:
         elevation = np.random.rand(np.prod(shape)).reshape(shape)
         uplift = np.zeros_like(elevation)

--- a/run_example.py
+++ b/run_example.py
@@ -68,12 +68,21 @@ def run(shape):
     my_ghosts = transform_values(my_ghosts, my_tile.global_to_local)
     their_ghosts = transform_values(their_ghosts, my_tile.global_to_local)
 
+    if mode == "odd-r":
+        shift = 0.5 if offset[0] % 2 else 0.0
+        xy_of_lower_left = (
+            (offset[1] + shift) * 100.0,
+            offset[0] * 100.0 * np.sqrt(3.0) / 2.0,
+        )
+    elif mode == "raster":
+        xy_of_lower_left = (offset[1] * 100.0, offset[0] * 100.0)
+
     grid = create_landlab_grid(
         partition,
-        xy_of_lower_left=offset,
+        xy_of_lower_left=xy_of_lower_left,
         spacing=100.0,
         id_=RANK,
-        mode="odd-r",
+        mode=mode,
     )
 
     grid.at_node["topographic__elevation"] = elevation.reshape(-1)


### PR DESCRIPTION
The lower-left corner of the tiles of the global grid were not being calculated correctly, so I've fixed that.