### PR TITLE
Add mode argument to the cli

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,3 +9,6 @@
   [#3](https://github.com/mcflugen/landlab-parallel/issues/3).
 - Fixed an issue where the lower-left corner of the tiles were not be calculated
   correctly [#4](https://github.com/mcflugen/landlab-parallel/issues/4).
+- Added a command-line argument, `mode`, that allows the user to modify
+  the type of grid used for the example
+  [#5](https://github.com/mcflugen/landlab-parallel/issues/5).

--- a/run_example.py
+++ b/run_example.py
@@ -29,7 +29,7 @@ def run(shape, mode):
         uplift = np.zeros_like(elevation)
         uplift[1:-1, 1:-1] = 0.1
 
-        tiler = RasterTiler.from_pymetis(shape, n_partitions, mode="odd-r")
+        tiler = RasterTiler.from_pymetis(shape, n_partitions, mode=mode)
 
         # print_output(tiler._partitions)
 

--- a/run_example.py
+++ b/run_example.py
@@ -127,6 +127,7 @@ def run(shape):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("size", type=int, help="Size of the grid")
+    parser.add_argument("--mode", choices=("raster", "odd-r"), help="Grid type")
 
     args = parser.parse_args()
 

--- a/run_example.py
+++ b/run_example.py
@@ -15,7 +15,7 @@ from landlab_parallel import pvtu_dump
 from landlab_parallel import vtu_dump
 
 
-def run(shape):
+def run(shape, mode):
     from mpi4py import MPI
 
     comm = MPI.COMM_WORLD
@@ -131,7 +131,7 @@ def main():
 
     args = parser.parse_args()
 
-    return run((args.size, 2 * args.size))
+    return run((args.size, 2 * args.size), args.mode)
 
 
 def print_output(array):


### PR DESCRIPTION
I've added a `--mode` argument to the cli of the example that allows the user to control the type of grid that's used.