### PR TITLE
Add seed argument to the cli

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,3 +12,6 @@
 - Added a command-line argument, `mode`, that allows the user to modify
   the type of grid used for the example
   [#5](https://github.com/mcflugen/landlab-parallel/issues/5).
+- Added a command-line argument, `seed`, that allows the user to provide
+  a seed for the random number generator used to create the initial elevations
+  [#6](https://github.com/mcflugen/landlab-parallel/issues/6).

--- a/run_example.py
+++ b/run_example.py
@@ -128,10 +128,13 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("size", type=int, help="Size of the grid")
     parser.add_argument("--mode", choices=("raster", "odd-r"), help="Grid type")
+    parser.add_argument(
+        "--seed", type=int, default=None, help="Random seed for initial elevations"
+    )
 
     args = parser.parse_args()
 
-    return run((args.size, 2 * args.size), args.mode)
+    return run((args.size, 2 * args.size), args.mode, args.seed)
 
 
 def print_output(array):

--- a/run_example.py
+++ b/run_example.py
@@ -15,7 +15,7 @@ from landlab_parallel import pvtu_dump
 from landlab_parallel import vtu_dump
 
 
-def run(shape, mode):
+def run(shape, mode="odd-r", seed=None):
     from mpi4py import MPI
 
     comm = MPI.COMM_WORLD
@@ -25,7 +25,8 @@ def run(shape, mode):
     mode = "odd-r"
 
     if RANK == 0:
-        elevation = np.random.rand(np.prod(shape)).reshape(shape)
+        rng = np.random.default_rng(seed=seed)
+        elevation = rng.uniform(size=shape)
         uplift = np.zeros_like(elevation)
         uplift[1:-1, 1:-1] = 0.1
 


### PR DESCRIPTION
I've added a `--seed` argument to the cli to the example so that the user can provide a seed for the random number generator used to initialize the elevations.