### PR TITLE
Fix bug that caused mode argument to be ignored

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,3 +20,5 @@
 - Modified the time loop to exchange ghost node data after every component is
   updated and also added drainage area to the list of data fields that are exchanged
   [#8](https://github.com/mcflugen/landlab-parallel/issues/8).
+- Fixed a bug where the mode passed from the cli was ignored
+  [#9](https://github.com/mcflugen/landlab-parallel/issues/9).

--- a/run_example.py
+++ b/run_example.py
@@ -22,8 +22,6 @@ def run(shape, mode="odd-r", seed=None):
     RANK = comm.Get_rank()
     n_partitions = comm.Get_size()
 
-    mode = "odd-r"
-
     if RANK == 0:
         rng = np.random.default_rng(seed=seed)
         elevation = rng.uniform(size=shape)


### PR DESCRIPTION
I've fixed a bug where the `--mode` option was being ignored.