### PR TITLE
Mask closed nodes when writing vtu files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,3 +22,5 @@
   [#8](https://github.com/mcflugen/landlab-parallel/issues/8).
 - Fixed a bug where the mode passed from the cli was ignored
   [#9](https://github.com/mcflugen/landlab-parallel/issues/9).
+- Mask-out data at closed nodes when writing to *vtu*
+  [#10](https://github.com/mcflugen/landlab-parallel/issues/10).

--- a/run_example.py
+++ b/run_example.py
@@ -105,10 +105,6 @@ def run(shape, mode="odd-r", seed=None):
                 (grid.at_node["topographic__elevation"], grid.at_node["drainage_area"]),
             )
 
-        send_receive_ghost_data(
-            comm, my_ghosts, their_ghosts, grid.at_node["topographic__elevation"]
-        )
-
     with open(f"{RANK}.vtu", "w") as fp:
         fp.write(vtu_dump(grid, z_coord="topographic__elevation"))
 


### PR DESCRIPTION
I've modified `vtu_dump` to (temporarily) set data at closed nodes to `nan`. This allows programs like *paraview* to not display the data at these nodes.