### PR TITLE
Normalize parameter names

### DIFF
--- a/landlab_parallel.py
+++ b/landlab_parallel.py
@@ -60,14 +60,14 @@ def get_my_ghost_nodes(
     else:
         raise ValueError(f"{mode}: mode not understood")
 
-    data_array = np.asarray(partitions)
-    is_my_node = data_array == my_id
+    partitions_array = np.asarray(partitions)
+    is_my_node = partitions_array == my_id
     is_ghost = get_ghosts(is_my_node)
-    neighbors = np.unique(data_array[~is_my_node & is_ghost])
+    neighbors = np.unique(partitions_array[~is_my_node & is_ghost])
 
     return {
         rank: np.ravel_multi_index(
-            np.nonzero(is_ghost & (data_array == rank)), data_array.shape
+            np.nonzero(is_ghost & (partitions_array == rank)), partitions_array.shape
         )
         for rank in neighbors
     }

--- a/landlab_parallel.py
+++ b/landlab_parallel.py
@@ -101,15 +101,17 @@ class Tile:
         """
         self._shape = tuple(shape)
         self._offset = tuple(offset)
-        self._data = np.asarray(partitions)
+        self._partitions = np.asarray(partitions)
         self._id = id_
 
         self._index_mapper = IndexMapper(
             self._shape,
-            submatrix=[(o, o + self._data.shape[dim]) for dim, o in enumerate(offset)],
+            submatrix=[
+                (o, o + self._partitions.shape[dim]) for dim, o in enumerate(offset)
+            ],
         )
 
-        self._ghost_nodes = get_my_ghost_nodes(self._data, my_id=id_, mode=mode)
+        self._ghost_nodes = get_my_ghost_nodes(self._partitions, my_id=id_, mode=mode)
 
     def local_to_global(self, indices: ArrayLike) -> NDArray[np.int_]:
         """Convert local node indices to global indices.

--- a/landlab_parallel.py
+++ b/landlab_parallel.py
@@ -706,7 +706,7 @@ def _submatrix_bounds(
 
 
 def create_landlab_grid(
-    partition: ArrayLike,
+    partitions: ArrayLike,
     spacing: float | tuple[float, float] = 1.0,
     ij_of_lower_left: tuple[int, int] = (0, 0),
     id_: int = 0,
@@ -716,7 +716,7 @@ def create_landlab_grid(
 
     Parameters
     ----------
-    partition : array_like
+    partitions : array_like
         Partition matrix describing ownership of each node.
     spacing : float or tuple of float, optional
         Grid spacing in the x and y directions.
@@ -732,7 +732,7 @@ def create_landlab_grid(
     landlab.ModelGrid
         The constructed grid with boundary conditions set.
     """
-    is_their_node = np.asarray(partition) != id_
+    is_their_node = np.asarray(partitions) != id_
 
     if mode == "odd-r":
         if not isinstance(spacing, float):
@@ -773,12 +773,12 @@ def create_landlab_grid(
     return grid
 
 
-def _d4_ghosts(partition: ArrayLike) -> NDArray[np.bool_]:
+def _d4_ghosts(partitions: ArrayLike) -> NDArray[np.bool_]:
     """Identify nodes that are ghost nodes.
 
     Parameters
     ----------
-    partition : array_like of int
+    partitions : array_like of int
         Partition matrix describing ownership of each node.
 
     Returns
@@ -815,28 +815,28 @@ def _d4_ghosts(partition: ArrayLike) -> NDArray[np.bool_]:
            [0, 0, 0, 1, 0],
            [0, 0, 0, 0, 1]])
     """
-    partition = np.pad(
-        partition,
+    partitions = np.pad(
+        partitions,
         pad_width=((1, 1), (1, 1)),
         mode="edge",
     )
 
-    right = partition[2:, 1:-1]
-    top = partition[1:-1, 2:]
-    left = partition[:-2, 1:-1]
-    bottom = partition[1:-1, :-2]
+    right = partitions[2:, 1:-1]
+    top = partitions[1:-1, 2:]
+    left = partitions[:-2, 1:-1]
+    bottom = partitions[1:-1, :-2]
 
-    core = partition[1:-1, 1:-1]
+    core = partitions[1:-1, 1:-1]
 
     return (core != right) | (core != top) | (core != left) | (core != bottom)
 
 
-def _d8_ghosts(partition: ArrayLike) -> NDArray[np.bool_]:
+def _d8_ghosts(partitions: ArrayLike) -> NDArray[np.bool_]:
     """Identify nodes that are ghost nodes, considering diagonals.
 
     Parameters
     ----------
-    partition : array_like of int
+    partitions : array_like of int
         Partition matrix describing ownership of each node.
 
     Returns
@@ -873,22 +873,22 @@ def _d8_ghosts(partition: ArrayLike) -> NDArray[np.bool_]:
            [0, 0, 1, 1, 0],
            [0, 0, 0, 1, 1]])
     """
-    partition = np.pad(
-        partition,
+    partitions = np.pad(
+        partitions,
         pad_width=((1, 1), (1, 1)),
         mode="edge",
     )
 
-    right = partition[1:-1, 2:]
-    top_right = partition[2:, 2:]
-    top = partition[2:, 1:-1]
-    top_left = partition[2:, :-2]
-    left = partition[1:-1, :-2]
-    bottom_left = partition[:-2, :-2]
-    bottom = partition[:-2, 1:-1]
-    bottom_right = partition[:-2, 2:]
+    right = partitions[1:-1, 2:]
+    top_right = partitions[2:, 2:]
+    top = partitions[2:, 1:-1]
+    top_left = partitions[2:, :-2]
+    left = partitions[1:-1, :-2]
+    bottom_left = partitions[:-2, :-2]
+    bottom = partitions[:-2, 1:-1]
+    bottom_right = partitions[:-2, 2:]
 
-    core = partition[1:-1, 1:-1]
+    core = partitions[1:-1, 1:-1]
 
     neighbors = np.stack(
         [right, top_right, top, top_left, left, bottom_left, bottom, bottom_right]
@@ -897,12 +897,12 @@ def _d8_ghosts(partition: ArrayLike) -> NDArray[np.bool_]:
     return np.any(core != neighbors, axis=0)
 
 
-def _odd_r_ghosts(partition: ArrayLike) -> NDArray[np.bool_]:
+def _odd_r_ghosts(partitions: ArrayLike) -> NDArray[np.bool_]:
     """Identify nodes that are ghost nodes on an odd-r layout.
 
     Parameters
     ----------
-    partition : array_like of int
+    partitions : array_like of int
         Partition matrix describing ownership of each node.
 
     Returns
@@ -939,18 +939,18 @@ def _odd_r_ghosts(partition: ArrayLike) -> NDArray[np.bool_]:
            [0, 0, 1, 1, 0],
            [0, 0, 0, 0, 1]])
     """
-    partition = np.pad(partition, pad_width=((1, 1), (1, 1)), mode="edge")
+    partitions = np.pad(partitions, pad_width=((1, 1), (1, 1)), mode="edge")
 
-    right = partition[1:-1, 2:]
-    top_right = partition[2:, 2:]
-    top = partition[2:, 1:-1]
-    top_left = partition[2:, :-2]
-    left = partition[1:-1, :-2]
-    bottom_left = partition[:-2, :-2]
-    bottom = partition[:-2, 1:-1]
-    bottom_right = partition[:-2, 2:]
+    right = partitions[1:-1, 2:]
+    top_right = partitions[2:, 2:]
+    top = partitions[2:, 1:-1]
+    top_left = partitions[2:, :-2]
+    left = partitions[1:-1, :-2]
+    bottom_left = partitions[:-2, :-2]
+    bottom = partitions[:-2, 1:-1]
+    bottom_right = partitions[:-2, 2:]
 
-    core = partition[1:-1, 1:-1]
+    core = partitions[1:-1, 1:-1]
 
     row_indices = np.indices(core.shape)[0]
     is_even_row = (row_indices % 2) == 0


### PR DESCRIPTION
I've renamed some parameter names so that they have consistent naming across functions. For example, previous to this pull request arrays that were partition ids were sometimes called `data`, `partition`, or `partitions`. They're now all called `partitions`.
