### PR TITLE
Clean up temporary files created with vtu_dump

### DIFF
--- a/src/landlab_parallel/landlab_parallel.py
+++ b/src/landlab_parallel/landlab_parallel.py
@@ -1015,13 +1015,7 @@ def vtu_dump(
     for name, array in saved_fields.items():
         grid.at_node[name] = array
 
-    with tempfile.NamedTemporaryFile(suffix=".vtu", delete=False) as tmp:
-        vtu_path = tmp.name
-    meshio.write(vtu_path, mesh)
-
-    with open(vtu_path, encoding="utf-8") as f:
-        contents = f.read()
-    os.remove(vtu_path)
+    contents = write_mesh_to_vtu_string(mesh)
 
     content = "\n".join(
         [
@@ -1105,3 +1099,15 @@ def convert_grid_to_mesh(
     finally:
         with contextlib.suppress(OSError):
             os.remove(vtk_path)
+
+
+def write_mesh_to_vtu_string(mesh: meshio.Mesh) -> str:
+    fd, vtu_path = tempfile.mkstemp(suffix=".vtu")
+    os.close(fd)
+    try:
+        meshio.write(vtu_path, mesh)
+        with open(vtu_path, encoding="utf-8") as stream:
+            return stream.read()
+    finally:
+        with contextlib.suppress(OSError):
+            os.remove(vtu_path)

--- a/src/landlab_parallel/landlab_parallel.py
+++ b/src/landlab_parallel/landlab_parallel.py
@@ -1007,23 +1007,29 @@ def vtu_dump(
         grid.at_node[name] = array.copy()
         grid.at_node[name][mask] = np.nan
 
-    with tempfile.NamedTemporaryFile(suffix=".vtk", mode="w+", delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(
+        suffix=".vtk", mode="w+", delete=False, encoding="utf-8"
+    ) as tmp:
         tmp.write(
             landlab.io.legacy_vtk.dump(
                 grid, include=include, exclude=exclude, z_coord=z_coord, at=at
             )
         )
         tmp.flush()
-        mesh = meshio.read(tmp.name)
+        vtk_path = tmp.name
+    mesh = meshio.read(vtk_path)
+    os.remove(vtk_path)
 
     for name, array in saved_fields.items():
         grid.at_node[name] = array
 
-    with tempfile.NamedTemporaryFile(suffix=".vtu", mode="r+", delete=False) as tmp:
-        tmp.close()
-        meshio.write(tmp.name, mesh)
-        with open(tmp.name, encoding="utf-8") as f:
-            contents = f.read()
+    with tempfile.NamedTemporaryFile(suffix=".vtu", delete=False) as tmp:
+        vtu_path = tmp.name
+    meshio.write(vtu_path, mesh)
+
+    with open(vtu_path, encoding="utf-8") as f:
+        contents = f.read()
+    os.remove(vtu_path)
 
     content = "\n".join(
         [


### PR DESCRIPTION
Some of the temporary files created with `vtu_dump` were not deteted, so I've fixed that.