### PR TITLE
Add adjacency module

### DIFF
--- a/src/landlab_parallel/adjacency.py
+++ b/src/landlab_parallel/adjacency.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def _get_d4_adjacency(shape: tuple[int, int]) -> list[list[int]]:
+    """Return D4 adjacency list for a raster grid.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Number of rows and columns in the grid.
+
+    Returns
+    -------
+    list[list[int]]
+        Adjacency list using D4 connectivity.
+    """
+    nodes = np.pad(
+        np.arange(shape[0] * shape[1]).reshape(shape),
+        pad_width=1,
+        mode="constant",
+        constant_values=-1,
+    )
+
+    d4_neighbors = np.stack(
+        [
+            nodes[1:-1, 2:],
+            nodes[2:, 1:-1],
+            nodes[1:-1, :-2],
+            nodes[:-2, 1:-1],
+        ],
+        axis=-1,
+    )
+
+    return [[int(x) for x in row[row != -1]] for row in d4_neighbors.reshape(-1, 4)]
+
+
+def _get_d8_adjacency(shape: tuple[int, int]) -> list[list[int]]:
+    """Return D8 adjacency list for a raster grid.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Number of rows and columns in the grid.
+
+    Returns
+    -------
+    list[list[int]]
+        Adjacency list using D8 connectivity.
+    """
+    nodes = np.pad(
+        np.arange(shape[0] * shape[1]).reshape(shape),
+        pad_width=1,
+        mode="constant",
+        constant_values=-1,
+    )
+
+    d8_neighbors = np.stack(
+        [
+            nodes[1:-1, 2:],
+            nodes[2:, 2:],
+            nodes[2:, 1:-1],
+            nodes[2:, :-2],
+            nodes[1:-1, :-2],
+            nodes[:-2, :-2],
+            nodes[:-2, 1:-1],
+            nodes[:-2, 2:],
+        ],
+        axis=-1,
+    )
+
+    return [[int(x) for x in row[row != -1]] for row in d8_neighbors.reshape(-1, 8)]
+
+
+def _get_odd_r_adjacency(shape: tuple[int, int]) -> list[list[int]]:
+    """Return adjacency list for a hex grid with odd-r layout.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Number of rows and columns in the grid.
+
+    Returns
+    -------
+    list[list[int]]
+        Adjacency list using odd-r connectivity.
+    """
+    nrows, ncols = shape
+    rows, cols = np.meshgrid(np.arange(nrows), np.arange(ncols), indexing="ij")
+    node_ids = rows * ncols + cols
+
+    even_offsets = np.array([[0, 1], [1, 0], [1, -1], [0, -1], [-1, -1], [-1, 0]])
+    odd_offsets = np.array([[0, 1], [1, 1], [1, 0], [0, -1], [-1, 0], [-1, 1]])
+
+    adjacency: list[list[int]] = [[] for _ in range(nrows * ncols)]
+
+    for parity, offsets in enumerate([even_offsets, odd_offsets]):
+        parity_mask = rows % 2 == parity
+
+        row_indices = rows[parity_mask]
+        col_indices = cols[parity_mask]
+        base_ids = node_ids[parity_mask]
+
+        for dr, dc in offsets:
+            r = row_indices + dr
+            c = col_indices + dc
+
+            valid = (0 <= r) & (r < nrows) & (0 <= c) & (c < ncols)
+            src = base_ids[valid]
+            dst = r[valid] * ncols + c[valid]
+
+            for s, d in zip(src, dst):
+                adjacency[s].append(int(d))
+
+    return adjacency

--- a/src/landlab_parallel/landlab_parallel.py
+++ b/src/landlab_parallel/landlab_parallel.py
@@ -12,6 +12,8 @@ import pymetis
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
+from landlab_parallel.adjacency import _get_d4_adjacency
+from landlab_parallel.adjacency import _get_odd_r_adjacency
 from landlab_parallel.ghosts import _d4_ghosts
 from landlab_parallel.ghosts import _odd_r_ghosts
 from landlab_parallel.ghosts import get_my_ghost_nodes
@@ -477,119 +479,6 @@ class IndexMapper:
             [coords[dim] - self._limits[dim][0] for dim in range(len(coords))],
             [limit[1] - limit[0] for limit in self._limits],
         )
-
-
-def _get_d4_adjacency(shape: tuple[int, int]) -> list[list[int]]:
-    """Return D4 adjacency list for a raster grid.
-
-    Parameters
-    ----------
-    shape : tuple of int
-        Number of rows and columns in the grid.
-
-    Returns
-    -------
-    list[list[int]]
-        Adjacency list using D4 connectivity.
-    """
-    nodes = np.pad(
-        np.arange(shape[0] * shape[1]).reshape(shape),
-        pad_width=1,
-        mode="constant",
-        constant_values=-1,
-    )
-
-    d4_neighbors = np.stack(
-        [
-            nodes[1:-1, 2:],
-            nodes[2:, 1:-1],
-            nodes[1:-1, :-2],
-            nodes[:-2, 1:-1],
-        ],
-        axis=-1,
-    )
-
-    return [[int(x) for x in row[row != -1]] for row in d4_neighbors.reshape(-1, 4)]
-
-
-def _get_d8_adjacency(shape: tuple[int, int]) -> list[list[int]]:
-    """Return D8 adjacency list for a raster grid.
-
-    Parameters
-    ----------
-    shape : tuple of int
-        Number of rows and columns in the grid.
-
-    Returns
-    -------
-    list[list[int]]
-        Adjacency list using D8 connectivity.
-    """
-    nodes = np.pad(
-        np.arange(shape[0] * shape[1]).reshape(shape),
-        pad_width=1,
-        mode="constant",
-        constant_values=-1,
-    )
-
-    d8_neighbors = np.stack(
-        [
-            nodes[1:-1, 2:],
-            nodes[2:, 2:],
-            nodes[2:, 1:-1],
-            nodes[2:, :-2],
-            nodes[1:-1, :-2],
-            nodes[:-2, :-2],
-            nodes[:-2, 1:-1],
-            nodes[:-2, 2:],
-        ],
-        axis=-1,
-    )
-
-    return [[int(x) for x in row[row != -1]] for row in d8_neighbors.reshape(-1, 8)]
-
-
-def _get_odd_r_adjacency(shape: tuple[int, int]) -> list[list[int]]:
-    """Return adjacency list for a hex grid with odd-r layout.
-
-    Parameters
-    ----------
-    shape : tuple of int
-        Number of rows and columns in the grid.
-
-    Returns
-    -------
-    list[list[int]]
-        Adjacency list using odd-r connectivity.
-    """
-    nrows, ncols = shape
-    rows, cols = np.meshgrid(np.arange(nrows), np.arange(ncols), indexing="ij")
-    node_ids = rows * ncols + cols
-
-    even_offsets = np.array([[0, 1], [1, 0], [1, -1], [0, -1], [-1, -1], [-1, 0]])
-    odd_offsets = np.array([[0, 1], [1, 1], [1, 0], [0, -1], [-1, 0], [-1, 1]])
-
-    adjacency: list[list[int]] = [[] for _ in range(nrows * ncols)]
-
-    for parity, offsets in enumerate([even_offsets, odd_offsets]):
-        parity_mask = rows % 2 == parity
-
-        row_indices = rows[parity_mask]
-        col_indices = cols[parity_mask]
-        base_ids = node_ids[parity_mask]
-
-        for dr, dc in offsets:
-            r = row_indices + dr
-            c = col_indices + dc
-
-            valid = (0 <= r) & (r < nrows) & (0 <= c) & (c < ncols)
-            src = base_ids[valid]
-            dst = r[valid] * ncols + c[valid]
-
-            for s, d in zip(src, dst):
-                adjacency[s].append(int(d))
-
-    return adjacency
 
 
 def _submatrix_bounds(


### PR DESCRIPTION
I've moved the functions that get adjacency nodes for various grid configurations (*d4*, *d8*, and *odd-r*) into a new module, `landlab_parallel.adjacency`.