### PR TITLE
Fix test and coverage nox sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Test
         run: |
           pip install nox
-          nox --non-interactive --error-on-missing-interpreter -s test -- dist/*whl
+          nox --non-interactive --error-on-missing-interpreter -s test -- dist/*.tar.gz
 
   coverage:
     needs: build-sdist

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,19 +40,10 @@ def install(session: nox.Session) -> None:
 @nox.session
 def test(session: nox.Session) -> None:
     """Run the tests."""
-    session.install("coverage", "pytest")
+    session.install("pytest")
     install(session)
 
-    session.run(
-        "coverage",
-        "run",
-        "--branch",
-        "--source=landlab_parallel,tests",
-        "--module",
-        "pytest",
-    )
-    session.run("coverage", "report", "--ignore-errors", "--show-missing")
-    session.run("coverage", "xml", "-o", "coverage.xml")
+    session.run("pytest", "--doctest-modules", "--pyargs", "landlab_parallel")
 
 
 @nox.session
@@ -67,7 +58,6 @@ def coverage(session: nox.Session) -> None:
         "-m",
         "pytest",
         "src/landlab_parallel",
-        "tests",
         "--doctest-modules",
         env={"COVERAGE_CORE": "sysmon"},
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,10 +62,8 @@ def coverage(session: nox.Session) -> None:
         env={"COVERAGE_CORE": "sysmon"},
     )
 
-    if "CI" in os.environ:
-        session.run("coverage", "xml", "-o", os.path.join(ROOT, "coverage.xml"))
-    else:
-        session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run("coverage", "xml", "-o", "coverage.xml")
 
 
 @nox.session


### PR DESCRIPTION
There were some issues with the *test* and *coverage* sessions in the *nox* file that I fixed. The main issue was that when running the doctests, *pytest* got confused as to what *landlab_parallel* to use—the installed version or the source under `src/landlab_parallel`. If a source distribution is provided, we want to install and test that version.