### PR TITLE
Modify create_landlab_grid to leave a partition's own nodes as core

### DIFF
--- a/src/landlab_parallel/grid.py
+++ b/src/landlab_parallel/grid.py
@@ -34,6 +34,15 @@ def create_landlab_grid(
     -------
     landlab.ModelGrid
         The constructed grid with boundary conditions set.
+
+    Notes
+    -----
+    The `status_at_node` array for the new grid is initialized as follows:
+
+    * Nodes owned by the partition are assigned ``NodeStatus.CORE``.
+    * Nodes shared with another grid (i.e., ghost nodes) are assigned
+      ``NodeStatus.FIXED_VALUE``.
+    * Nodes owned by other partitions are assigned ``NodeStatus.CLOSED``.
     """
     is_their_node = np.asarray(partitions) != id_
 

--- a/src/landlab_parallel/grid.py
+++ b/src/landlab_parallel/grid.py
@@ -70,6 +70,7 @@ def create_landlab_grid(
     is_ghost_node = get_ghosts(~is_their_node).reshape(-1)
     is_their_node.shape = (-1,)
 
+    grid.status_at_node.fill(landlab.NodeStatus.CORE)
     grid.status_at_node[is_their_node] = np.where(
         is_ghost_node[is_their_node],
         landlab.NodeStatus.FIXED_VALUE,

--- a/tests/grid_test.py
+++ b/tests/grid_test.py
@@ -11,13 +11,14 @@ def test_grid_d4():
         [0, 0, 0, 1],
     ]
     grid = create_landlab_grid(partitions, id_=0, mode="d4")
+
     assert grid.shape == (4, 4)
     assert_array_equal(
         grid.status_at_node.reshape(grid.shape),
         [
-            [1, 1, 1, 1],
-            [1, 0, 1, 4],
-            [1, 0, 1, 4],
-            [1, 1, 1, 1],
+            [0, 0, 0, 1],
+            [0, 0, 1, 4],
+            [0, 0, 1, 4],
+            [0, 0, 0, 1],
         ],
     )


### PR DESCRIPTION
When creating a grid from a partition matrix, don't know the status for the nodes owned by the partition. As such, I've change `create_landlab_grid` to set the status of the nodes owned by the partition to `CORE`. It's then up to the user to set the node status of the partitions based on the global grid.