### PR TITLE
Add halo keyword to the from_pymetis class method

### DIFF
--- a/examples/run_lem_example.py
+++ b/examples/run_lem_example.py
@@ -31,9 +31,9 @@ def run(shape, mode="odd-r", seed=None):
         uplift_rate[1:-1, 1:-1] = 0.004
 
         if mode == "odd-r":
-            tiler = OddRTiler.from_pymetis(shape, n_partitions)
+            tiler = OddRTiler.from_pymetis(shape, n_partitions, halo=2)
         else:
-            tiler = D4Tiler.from_pymetis(shape, n_partitions)
+            tiler = D4Tiler.from_pymetis(shape, n_partitions, halo=2)
 
         for _rank in range(1, n_partitions):
             ij_of_lower_left = np.asarray([s.start for s in tiler[_rank]], dtype="i")

--- a/src/landlab_parallel/tiler.py
+++ b/src/landlab_parallel/tiler.py
@@ -242,7 +242,7 @@ class Tiler(Mapping, ABC):
         return out
 
     @classmethod
-    def from_pymetis(cls, shape: tuple[int, int], n_tiles: int) -> Self:
+    def from_pymetis(cls, shape: tuple[int, int], n_tiles: int, halo: int = 0) -> Self:
         """Partition ``shape`` into ``n_tiles`` using PyMetis.
 
         Parameters
@@ -251,6 +251,8 @@ class Tiler(Mapping, ABC):
             Shape of the grid to partition.
         n_tiles : int
             Desired number of tiles.
+        halo : int
+            The size of the halo of nodes to include in the tile.
 
         Returns
         -------
@@ -259,7 +261,7 @@ class Tiler(Mapping, ABC):
         """
         _, partitions = pymetis.part_graph(n_tiles, adjacency=cls.get_adjacency(shape))
 
-        return cls(np.asarray(partitions).reshape(shape))
+        return cls(np.asarray(partitions).reshape(shape), halo=halo)
 
     @classmethod
     def get_adjacency(cls, shape: tuple[int, int]) -> list[list[int]]:

--- a/tests/tiler_test.py
+++ b/tests/tiler_test.py
@@ -54,3 +54,9 @@ def test_tiler_halo(halo):
     tiler = D4Tiler(partitions, halo=halo)
     assert tiler.get_tile_size(0) == n**2
     assert tiler.getvalue(0).shape == (n, n)
+
+
+@pytest.mark.parametrize("halo", (0, 1, 2, 3))
+def test_tiler_halo_with_pymetis(halo):
+    tiler = D4Tiler.from_pymetis((32, 32), 2, halo=halo)
+    assert len(tiler) == 2


### PR DESCRIPTION
I've added a `halo` keyword to `Tiler.from_pymetis`. This is something I forgot to do this in #39.