### PR TITLE
Use d4 instead of raster for mode keyword

### DIFF
--- a/examples/run_lem_example.py
+++ b/examples/run_lem_example.py
@@ -132,7 +132,7 @@ class Uplift:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("size", type=int, help="Size of the grid")
-    parser.add_argument("--mode", choices=("raster", "odd-r"), help="Grid type")
+    parser.add_argument("--mode", choices=("d4", "odd-r"), help="Grid type")
     parser.add_argument(
         "--seed", type=int, default=None, help="Random seed for initial elevations"
     )

--- a/src/landlab_parallel/ghosts.py
+++ b/src/landlab_parallel/ghosts.py
@@ -16,7 +16,7 @@ def get_my_ghost_nodes(
         Partition matrix describing ownership of each node.
     my_id : int, optional
         Identifier of the local partition.
-    mode : {"d4", "d8", "odd-r", "raster"}, optional
+    mode : {"d4", "d8", "odd-r"}, optional
         Connectivity scheme used to determine neighbors.
 
     Returns
@@ -39,7 +39,6 @@ def get_my_ghost_nodes(
         "d4": _d4_ghosts,
         "d8": _d8_ghosts,
         "odd-r": _odd_r_ghosts,
-        "raster": _d4_ghosts,
     }
     try:
         get_ghosts = mode_handlers[mode]

--- a/src/landlab_parallel/grid.py
+++ b/src/landlab_parallel/grid.py
@@ -13,7 +13,7 @@ def create_landlab_grid(
     spacing: float | tuple[float, float] = 1.0,
     ij_of_lower_left: tuple[int, int] = (0, 0),
     id_: int = 0,
-    mode="raster",
+    mode="d4",
 ) -> landlab.ModelGrid:
     """Create a Landlab grid from a partition matrix.
 
@@ -27,7 +27,7 @@ def create_landlab_grid(
         Index of the lower-left node of the tile within the full grid.
     id_ : int, optional
         Identifier of the local tile.
-    mode : {"raster", "odd-r", "d4"}, optional
+    mode : {"odd-r", "d4"}, optional
         Grid type describing connectivity.
 
     Returns
@@ -48,10 +48,10 @@ def create_landlab_grid(
             (ij_of_lower_left[1] + shift) * spacing,
             ij_of_lower_left[0] * spacing * np.sqrt(3.0) / 2.0,
         )
-    elif mode == "raster":
+    elif mode == "d4":
         xy_of_lower_left = tuple(np.multiply(ij_of_lower_left, spacing))
 
-    if mode in ("d4", "raster"):
+    if mode == "d4":
         grid = landlab.RasterModelGrid(
             is_their_node.shape,
             xy_spacing=spacing,

--- a/src/landlab_parallel/tiler.py
+++ b/src/landlab_parallel/tiler.py
@@ -25,7 +25,7 @@ class Tile:
         shape: tuple[int, ...],
         partitions: ArrayLike,
         id_: int,
-        mode: str = "raster",
+        mode: str = "d4",
     ):
         """Create a tile.
 
@@ -39,7 +39,7 @@ class Tile:
             Partition matrix describing ownership of each node.
         id_ : int
             Identifier of the local tile.
-        mode : {"d4", "d8", "odd-r", "raster"}, optional
+        mode : {"d4", "d8", "odd-r"}, optional
             Connectivity scheme used to determine neighbors.
         """
         self._shape = tuple(shape)


### PR DESCRIPTION
The string `"raster"` was being used as an alias for `"d4"` but that could be confusing a `"d8"` could also be thought of as raster. I've dropped `"raster"` as a valid mode, using `"d4"` instead.