### PR TITLE
Add utility functions for identifying ghost nodes

### DIFF
--- a/examples/run_lem_example.py
+++ b/examples/run_lem_example.py
@@ -74,7 +74,9 @@ def run(shape, mode="odd-r", seed=None):
 
     my_tile = Tile(ij_of_lower_left, shape, partition, id_=RANK, mode=mode)
 
-    my_ghosts = transform_values(my_tile._ghost_nodes, my_tile.local_to_global)
+    my_ghosts = transform_values(
+        dict(my_tile.get_ghost_nodes_by_owner()), my_tile.local_to_global
+    )
     their_ghosts = send_receive_ghost_ids(comm, my_ghosts)
 
     my_ghosts = transform_values(my_ghosts, my_tile.global_to_local)

--- a/src/landlab_parallel/ghosts.py
+++ b/src/landlab_parallel/ghosts.py
@@ -120,7 +120,7 @@ def is_non_ghost_of_partition(
     return ~is_ghost(is_local_partition, mode=mode) & is_local_partition
 
 
-def get_my_ghost_nodes(
+def get_ghosts_by_owner(
     partitions: ArrayLike, my_id: int = 0, mode: str = "d4"
 ) -> dict[int, NDArray[np.int_]]:
     """Return ghost node indices for a given partition.
@@ -146,7 +146,7 @@ def get_my_ghost_nodes(
     ...     [0, 1, 1],
     ...     [2, 2, 1],
     ... ]
-    >>> result = get_my_ghost_nodes(partitions, my_id=0)
+    >>> result = get_ghosts_by_owner(partitions, my_id=0)
     >>> {int(rank): nodes.tolist() for rank, nodes in result.items()}
     {1: [2, 4], 2: [6]}
     """

--- a/src/landlab_parallel/ghosts.py
+++ b/src/landlab_parallel/ghosts.py
@@ -83,6 +83,43 @@ def is_ghost_of_partition(
     return is_ghost(is_local_partition, mode=mode) & (~is_local_partition)
 
 
+def is_non_ghost_of_partition(
+    partitions: ArrayLike, partition: int, mode: str = "d4"
+) -> NDArray[np.bool_]:
+    """Identify nodes that are only part of a given partition.
+
+    Parameters
+    ----------
+    partitions : array_like
+        Partition matrix describing ownership of each node.
+    partition : int
+        Identifier of the local partition.
+    mode : {"d4", "d8", "odd-r"}, optional
+        Connectivity scheme used to determine neighbors.
+
+    Returns
+    -------
+    ndarray of bool
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> partitions = np.asarray(
+    ...     [
+    ...         [0, 0, 0, 1, 2, 2, 2],
+    ...         [0, 0, 1, 1, 1, 2, 2],
+    ...         [0, 1, 1, 1, 1, 1, 2],
+    ...     ]
+    ... )
+    >>> is_non_ghost_of_partition(partitions, 2).astype(int)
+    array([[0, 0, 0, 0, 0, 1, 1],
+           [0, 0, 0, 0, 0, 0, 1],
+           [0, 0, 0, 0, 0, 0, 0]])
+    """
+    is_local_partition = np.asarray(partitions) == partition
+    return ~is_ghost(is_local_partition, mode=mode) & is_local_partition
+
+
 def get_my_ghost_nodes(
     partitions: ArrayLike, my_id: int = 0, mode: str = "d4"
 ) -> dict[int, NDArray[np.int_]]:

--- a/src/landlab_parallel/ghosts.py
+++ b/src/landlab_parallel/ghosts.py
@@ -50,6 +50,39 @@ def is_ghost(partitions: ArrayLike, mode: str = "d4") -> NDArray[np.bool_]:
     return get_ghosts(partitions)
 
 
+def is_ghost_of_partition(
+    partitions: ArrayLike, partition: int, mode: str = "d4"
+) -> NDArray[np.bool_]:
+    """Identify nodes that are ghosts of a given partition.
+
+    Parameters
+    ----------
+    partitions : array_like
+        Partition matrix describing ownership of each node.
+    partition : int
+        Identifier of the local partition.
+    mode : {"d4", "d8", "odd-r"}, optional
+        Connectivity scheme used to determine neighbors.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> partitions = np.asarray(
+    ...     [
+    ...         [0, 0, 0, 1, 2, 2, 2],
+    ...         [0, 0, 1, 1, 1, 2, 2],
+    ...         [0, 1, 1, 1, 1, 1, 2],
+    ...     ]
+    ... )
+    >>> is_ghost_of_partition(partitions, 1).astype(int)
+    array([[0, 0, 1, 0, 1, 0, 0],
+           [0, 1, 0, 0, 0, 1, 0],
+           [1, 0, 0, 0, 0, 0, 1]])
+    """
+    is_local_partition = np.asarray(partitions) == partition
+    return is_ghost(is_local_partition, mode=mode) & (~is_local_partition)
+
+
 def get_my_ghost_nodes(
     partitions: ArrayLike, my_id: int = 0, mode: str = "d4"
 ) -> dict[int, NDArray[np.int_]]:

--- a/src/landlab_parallel/tiler.py
+++ b/src/landlab_parallel/tiler.py
@@ -12,7 +12,7 @@ from numpy.typing import NDArray
 
 from landlab_parallel.adjacency import _get_d4_adjacency
 from landlab_parallel.adjacency import _get_odd_r_adjacency
-from landlab_parallel.ghosts import get_my_ghost_nodes
+from landlab_parallel.ghosts import get_ghosts_by_owner
 from landlab_parallel.index_mapper import IndexMapper
 
 
@@ -54,7 +54,7 @@ class Tile:
             ],
         )
 
-        self._ghost_nodes = get_my_ghost_nodes(self._partitions, my_id=id_, mode=mode)
+        self._ghost_nodes = get_ghosts_by_owner(self._partitions, my_id=id_, mode=mode)
 
     def local_to_global(self, indices: ArrayLike) -> NDArray[np.int_]:
         """Convert local node indices to global indices.

--- a/src/landlab_parallel/tiler.py
+++ b/src/landlab_parallel/tiler.py
@@ -56,6 +56,11 @@ class Tile:
 
         self._ghost_nodes = get_ghosts_by_owner(self._partitions, my_id=id_, mode=mode)
 
+    def get_ghost_nodes_by_owner(self) -> tuple[tuple[int, NDArray[np.int_]], ...]:
+        return tuple(
+            (int(owner), nodes.copy()) for owner, nodes in self._ghost_nodes.items()
+        )
+
     def local_to_global(self, indices: ArrayLike) -> NDArray[np.int_]:
         """Convert local node indices to global indices.
 

--- a/src/landlab_parallel/tiler.py
+++ b/src/landlab_parallel/tiler.py
@@ -57,6 +57,24 @@ class Tile:
         self._ghost_nodes = get_ghosts_by_owner(self._partitions, my_id=id_, mode=mode)
 
     def get_ghost_nodes_by_owner(self) -> tuple[tuple[int, NDArray[np.int_]], ...]:
+        """Get ghost-node indices grouped by their owning partition.
+
+        Get the *ghost nodes* needed by the current partition (i.e., nodes not
+        owned locally but required to assemble/connect elements on the partition
+        boundary) and groups them by the neighboring partition that owns them.
+        The node IDs those of the current partition.
+
+        Returns
+        -------
+        tuple of (int, ndarray)
+            A tuple where each item is a pair ``(owner, nodes)``:
+
+            - ``owner`` : int
+                Identifier (e.g., rank/partition ID) of the neighboring partition
+                that owns the nodes.
+            - ``nodes`` : ndarray of int, shape (N,)
+                One-dimensional array of ghost node IDs owned by ``owner``.
+        """
         return tuple(
             (int(owner), nodes.copy()) for owner, nodes in self._ghost_nodes.items()
         )

--- a/tests/ghosts_test.py
+++ b/tests/ghosts_test.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from landlab_parallel.ghosts import is_ghost
+
+
+@pytest.mark.parametrize("mode", ("d4", "d8", "odd-r"))
+@pytest.mark.parametrize(
+    "partitions",
+    (
+        [[0, 0, 0, 1], [0, 0, 1, 1], [0, 1, 1, 1]],
+        [[0, 0, 2, 2]],
+        np.asarray([[0, 0, 0, 1], [0, 0, 1, 1], [0, 1, 1, 1]]),
+    ),
+)
+def test_is_ghost_shape_and_type(mode, partitions):
+    actual = is_ghost(partitions)
+    assert actual.dtype == bool
+    assert actual.shape == np.asarray(partitions).shape
+
+
+@pytest.mark.parametrize("mode", ("D4", "d5", "", None, 4))
+def test_is_ghost_with_bad_mode(mode):
+    with pytest.raises(ValueError):
+        is_ghost([[0, 0, 1], [0, 1, 1], [1, 1, 1]], mode=mode)
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        (
+            "d4",
+            [
+                [0, 0, 1, 1],
+                [0, 1, 1, 0],
+                [1, 1, 0, 0],
+            ],
+        ),
+        (
+            "d8",
+            [
+                [0, 1, 1, 1],
+                [1, 1, 1, 1],
+                [1, 1, 1, 0],
+            ],
+        ),
+        (
+            "odd-r",
+            [
+                [0, 0, 1, 1],
+                [1, 1, 1, 0],
+                [1, 1, 1, 0],
+            ],
+        ),
+    ],
+)
+def test_is_ghost(mode, expected):
+    partitions = [
+        [0, 0, 0, 1],
+        [0, 0, 1, 1],
+        [0, 1, 1, 1],
+    ]
+    actual = is_ghost(partitions, mode=mode)
+    assert_array_equal(actual, np.asarray(expected, dtype=bool))

--- a/tests/tiler_test.py
+++ b/tests/tiler_test.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from landlab_parallel.tiler import D4Tiler
+from landlab_parallel.tiler import Tile
 
 
 @pytest.mark.parametrize(
@@ -60,3 +62,22 @@ def test_tiler_halo(halo):
 def test_tiler_halo_with_pymetis(halo):
     tiler = D4Tiler.from_pymetis((32, 32), 2, halo=halo)
     assert len(tiler) == 2
+
+
+def test_tile():
+    tile = Tile(
+        (0, 0),
+        (64, 64),
+        [
+            [1, 1, 1, 2, 2],
+            [1, 1, 2, 2, 2],
+            [1, 2, 2, 2, 3],
+        ],
+        1,
+    )
+    expected = {2: [3, 7, 11]}
+    actual = tile._ghost_nodes
+
+    assert actual.keys() == expected.keys()
+    for owner in tile._ghost_nodes:
+        assert_array_equal(actual[owner], expected[owner])

--- a/tests/tiler_test.py
+++ b/tests/tiler_test.py
@@ -75,9 +75,11 @@ def test_tile():
         ],
         1,
     )
-    expected = {2: [3, 7, 11]}
-    actual = tile._ghost_nodes
+    expected = ((2, [3, 7, 11]),)
+    actual = tile.get_ghost_nodes_by_owner()
 
-    assert actual.keys() == expected.keys()
-    for owner in tile._ghost_nodes:
-        assert_array_equal(actual[owner], expected[owner])
+    assert len(actual) == len(expected)
+    for actual_item, expected_item in zip(actual, expected):
+        assert len(actual_item) == len(expected_item)
+        assert actual_item[0] == expected_item[0]
+        assert_array_equal(actual_item[1], expected_item[1])


### PR DESCRIPTION
I've added some new convenience functions for identifying ghost (and non-ghost) nodes from a partition matrix.