### PR TITLE
Update mypy pre commit hook to point to src directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,4 +71,5 @@ repos:
   - id: mypy
     language_version: python3.12
     additional_dependencies: [numpy]
-    files: landlab_parallel\.py$
+    types: [python]
+    files: ^src/landlab_parallel/

--- a/src/landlab_parallel/utilities.py
+++ b/src/landlab_parallel/utilities.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 from numpy.typing import DTypeLike
 
 
 def build_csr_array(
-    rows: Sequence[ArrayLike],
+    rows: Sequence[Sequence[Any]],
     dtype: DTypeLike = None,
 ):
     """Represent a jagged array in compressed sparse row form.


### PR DESCRIPTION
The *mypy* *pre-commit* hook was still pointing to the old source code location. It now points to `src/landlab_parallel`.