### PR TITLE
Update license metadata for pep639

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Test
         run: |
           pip install nox
-          nox --non-interactive --error-on-missing-interpreter -s test -- dist/*.tar.gz
+          nox -s test -- dist/*.tar.gz
 
   coverage:
     needs: build-sdist
@@ -134,7 +134,7 @@ jobs:
       - name: Test
         run: |
           pip install nox
-          nox --non-interactive --error-on-missing-interpreter -s coverage
+          nox -s coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ keywords = [
   'python',
 ]
 license = "MIT"
+license-files = ["LICENSE.md"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering :: Physics",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
   'parallel',
   'python',
 ]
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Operating System :: OS Independent",

--- a/src/landlab_parallel/_version.py
+++ b/src/landlab_parallel/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0.dev1"


### PR DESCRIPTION
I've updated the license metadata to be compliant with [PEP639](https://peps.python.org/pep-0639/).